### PR TITLE
如果文件夹或者md文件是中文文件名，默认编码是小写，正常应该是大写

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -66,7 +66,7 @@ func RunWeb(ctx *cli.Context) error {
 
 		navs, firstNav := getNavs(activeNav)
 
-		firstLink := strings.TrimPrefix(firstNav.Link, "/")
+		firstLink := utils.CustomURLEncode(strings.TrimPrefix(firstNav.Link, "/"))
 		if setIndexAuto && Index != firstLink {
 			Index = firstLink
 		}

--- a/internal/utils/encode.go
+++ b/internal/utils/encode.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"net/url"
+	"strings"
+)
+
+func CustomURLEncode(str string) string {
+	var encodedParts []string
+	parts := strings.Split(str, "/")
+
+	for _, part := range parts {
+		if isChinese(part) {
+			part = url.QueryEscape(part)
+		}
+		encodedParts = append(encodedParts, part)
+	}
+
+	return strings.Join(encodedParts, "/")
+}
+
+func isChinese(s string) bool {
+	for _, r := range s {
+		if r >= 0x4E00 && r <= 0x9FFF {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/utils/explorer.go
+++ b/internal/utils/explorer.go
@@ -95,7 +95,7 @@ func explorerRecursive(node *Node, option *Option) {
 		// 目录（或文件）名
 		child.Name = f.Name()
 		// 访问路径
-		child.Link = strings.TrimPrefix(strings.TrimSuffix(tmp, path.Ext(f.Name())), CurDirPath)
+		child.Link = CustomURLEncode(strings.TrimPrefix(strings.TrimSuffix(tmp, path.Ext(f.Name())), CurDirPath))
 
 		// 目录或文件名（不包含后缀）
 		child.ShowName = strings.TrimSuffix(f.Name(), path.Ext(f.Name()))

--- a/web/views/layouts/layout.html
+++ b/web/views/layouts/layout.html
@@ -13,6 +13,7 @@
 	<link rel="stylesheet" href="/static/css/gitbook-theme/splitter.css">
 	<link rel="stylesheet" href="/static/css/highlight-theme/a11y-dark.css">
 	<link rel="stylesheet" href="/static/css/main.css">
+	<link href="http://www.beitai.cc:9999/dist/Artalk.css" rel="stylesheet">
 
 	{{ if .Gitalk.ClientID }}
 	<link rel="stylesheet" href="/static/css/gitalk/gitalk.css">
@@ -80,6 +81,20 @@
 <script src="/static/js/chapter-fold.js"></script>
 <script src="/static/js/splitter.js"></script>
 <script src="/static/js/main.js"></script>
+<script src="http://www.beitai.cc:9999/dist/Artalk.js"></script>
+
+<div id="Comments"></div>
+<script>
+Artalk.init({
+  el:        '#Comments',                // 绑定元素的 Selector
+  pageKey:   '',                  // 固定链接 (留空自动获取)
+  pageTitle: '',  // 页面标题 (留空自动获取)
+  server:    'http://www.beitai.cc:9999',  // 后端地址
+  site:      '备胎书屋',             // 你的站点名
+})
+</script>
+
+
 {{ if .Gitalk.ClientID }}
 <script src="/static/js/gitalk.min.js"></script>
 <script>

--- a/web/views/layouts/layout.html
+++ b/web/views/layouts/layout.html
@@ -13,7 +13,6 @@
 	<link rel="stylesheet" href="/static/css/gitbook-theme/splitter.css">
 	<link rel="stylesheet" href="/static/css/highlight-theme/a11y-dark.css">
 	<link rel="stylesheet" href="/static/css/main.css">
-	<link href="http://www.beitai.cc:9999/dist/Artalk.css" rel="stylesheet">
 
 	{{ if .Gitalk.ClientID }}
 	<link rel="stylesheet" href="/static/css/gitalk/gitalk.css">
@@ -81,20 +80,6 @@
 <script src="/static/js/chapter-fold.js"></script>
 <script src="/static/js/splitter.js"></script>
 <script src="/static/js/main.js"></script>
-<script src="http://www.beitai.cc:9999/dist/Artalk.js"></script>
-
-<div id="Comments"></div>
-<script>
-Artalk.init({
-  el:        '#Comments',                // 绑定元素的 Selector
-  pageKey:   '',                  // 固定链接 (留空自动获取)
-  pageTitle: '',  // 页面标题 (留空自动获取)
-  server:    'http://www.beitai.cc:9999',  // 后端地址
-  site:      '备胎书屋',             // 你的站点名
-})
-</script>
-
-
 {{ if .Gitalk.ClientID }}
 <script src="/static/js/gitalk.min.js"></script>
 <script>


### PR DESCRIPTION
如果文件夹或者md文件是中文文件名，默认编码是小写，正常应该是大写，目前主流浏览器全部是大写。

比如

https://github.com/啊

在浏览器复制粘贴后，中文会被编码成大写，某些设备上浏览器版本较低，如果中文以小写编码会打不开。

https://github.com/%E5%95%8A