### PR TITLE
Update app.go 浏览器标题栏显示md文件名为标题

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -258,7 +258,9 @@ func articleHandler(ctx iris.Context) {
 		ctx.Application().Logger().Errorf("ReadFile Error '%s', Path is %s", mdfile, ctx.Path())
 		return
 	}
-
+	tmp := strings.Split(f, "/")
+	title := tmp[len(tmp)-1]
+	ctx.ViewData("Title", title+" - "+Title)
 	ctx.ViewData("Article", mdToHtml(bytes))
 
 	ctx.View("index.html")


### PR DESCRIPTION
标题显示为.md文件名，代码来自于chatgpt3.5，测试没问题。