### PR TITLE
Update explorer.go

### DIFF
--- a/internal/utils/explorer.go
+++ b/internal/utils/explorer.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"math/rand"
 )
 
 // Node 树节点
@@ -21,10 +22,10 @@ type Node struct {
 
 // Option 遍历选项
 type Option struct {
-	RootPath   []string `yaml:"rootPath"`   // 目标根目录
-	SubFlag    bool     `yaml:"subFlag"`    // 遍历子目录标志 true: 遍历 false: 不遍历
-	IgnorePath []string `yaml:"ignorePath"` // 忽略目录
-	IgnoreFile []string `yaml:"ignoreFile"` // 忽略文件
+	RootPath         []string `yaml:"rootPath"`         // 目标根目录
+	SubFlag          bool     `yaml:"subFlag"`          // 遍历子目录标志 true: 遍历 false: 不遍历
+	IgnorePath       []string `yaml:"ignorePath"`       // 忽略目录
+	IgnoreFile       []string `yaml:"ignoreFile"`       // 忽略文件
 }
 
 // 当前再循环的Dir路径
@@ -87,6 +88,8 @@ func explorerRecursive(node *Node, option *Option) {
 		return
 	}
 
+	var mdFiles []*Node
+
 	for _, f := range sub {
 		tmp := path.Join(node.Path, f.Name())
 		var child Node
@@ -126,7 +129,17 @@ func explorerRecursive(node *Node, option *Option) {
 				continue
 			}
 
-			node.Children = append(node.Children, &child)
+			mdFiles = append(mdFiles, &child)
 		}
+	}
+
+	// 超过指定数量的.md文件进行随机展示
+	if len(mdFiles) > 150 {
+		rand.Shuffle(len(mdFiles), func(i, j int) {
+			mdFiles[i], mdFiles[j] = mdFiles[j], mdFiles[i]
+		})
+		node.Children = append(node.Children, mdFiles[:150]...)
+	} else {
+		node.Children = append(node.Children, mdFiles...)
 	}
 }


### PR DESCRIPTION
我的小站有几个文件夹.md文件都在2000个左右。

每次访问任何页面，左边导航都会扫描所有.md文件，列出，导致页面文件很大。

让chatgpt3.5修改了explorer.go

添加了一个名为mdFiles的切片，用于存储文件夹中的.md文件。在遍历结束后，根据RandomFileLimit的值决定是否进行随机展示。

如果mdFiles中的文件数量超过了RandomFileLimit，则进行随机打乱并截取RandomFileLimit个文件，否则将所有文件都添加到结果中。

我这里将代码写死了，当文件夹超过150个文件，左边导航栏将只展示此文件夹下随机150个文件。

如果不超过150个，还按照原来逻辑。

作者你看需要合并么。

是不是可以加入到参数中，将RandomFileLimit数值。